### PR TITLE
Clarify textual identity format

### DIFF
--- a/spec/protocol/identity.adoc
+++ b/spec/protocol/identity.adoc
@@ -48,7 +48,35 @@ This allows for 31 bits of subresource.
 |===
 
 == Textual Format
-To render an identity into a textual version.
+The string format for an identity is the concatenation of:
 
-The string format is the character `o` followed by 3 characters that represent the checksum, followed by the content of the identity itself.
+- the character `m`,
+- the base32 encoding (RFC4648 alphabet, all lowercase) of the identity binary value itself,
+- the first 2 characters of the base32 encoding (RFC4648 alphabet, all lowercase) of the calculated checksum (see below).
 
+The exception is anonymous, which can be reduced to `maa` (no encoding of the identity itself).
+
+=== Checksum
+The checksum is the CRC16 checksum (polynomial 0xA001, initial value 0x0000, xor 0x0000, with reflection) of the identity bytestring.
+Then the Base32 encoding of this checksum is calculated (RFC4648 alphabet, all lowercase), and the first 2 characters of the encoded string is used as checksum in the textual format.
+
+==== Security Considerations
+A Base32 character has 32 possible values, or 5 bits of entropy.
+Two characters give us 10 bits of entropy, which indicates that two typos on a textual identity has a (1 out of 1024)^2 chance of matching, assuming these typos are randomly distributed.
+
+The Checksum therefore should not be considered secure for preventing collisions (e.g. for hashing), but it is only useful when manually entering identities from the keyboard.
+As such, the risk of collision is acceptable in the case of manual data entry.
+
+=== Examples
+The following identities can be used as examples:
+
+[stripes=odd]
+|===
+| Identity Bytes | Textual Format
+| `0x00` (Anonymous) | `maa` or `maaaa`
+| `0x0100000000000000000000000000000000000000000000000000000000` | `maeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah`
+| `0x8000000000000000000000000000000000000000000000000000000000000000` | `mqaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaayb`
+| `0x8000000000000000000000000000000000000000000000000000000000000001` | `mqaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqac`
+| `0x0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D` | `maebagbafaydqqcikbmga2dqpcaireeyuculbogazdinryhito`
+| `0x8102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D828384` | `mqebagbafaydqqcikbmga2dqpcaireeyuculbogazdinryhmcqocauk`
+|===


### PR DESCRIPTION
And change its prefix from `o` to `m`.

Fixes #18