### PR TITLE
Update IdStore spec with public key

### DIFF
--- a/attributes/network/1002_idstore.adoc
+++ b/attributes/network/1002_idstore.adoc
@@ -1,8 +1,9 @@
 = ID Store Attribute (#1002)
 :cddl: ./cddl/
 
-Servers use this attribute to implement an identity store containing a map of recall phrase to credential ID and a map of public address to credential ID. 
+Servers use this attribute to implement an identity store containing a map of recall phrase to credential ID and public key and a map of public address to credential ID and public key. 
 The credential ID is at least 16 bytes long and at most 1023 bytes long.
+The public key is a CBOR serialized COSE_Key.
 
 It does not have to be backed by a blockchain (but it MAY be if it implements attribute #1).
 
@@ -10,9 +11,9 @@ A user cannot modify an entry after it is stored.
 
 It exposes the following endpoints:
 
-- <<_store, `idstore.store`>>. Store new credential ID and address in the persistent storage and return the associated recall phrase.
-- <<_getfromrecallphrase, `idstore.getFromRecallPhrase`>>. Get the credential ID associated to the given recall phrase.
-- <<_getfromaddress, `idstore.getFromAddress`>>. Get the credential ID associated to the given public address.
+- <<_store, `idstore.store`>>. Store new credential ID, public key, and address in the persistent storage and return the associated recall phrase.
+- <<_getfromrecallphrase, `idstore.getFromRecallPhrase`>>. Get the credential ID and public key associated with the given recall phrase.
+- <<_getfromaddress, `idstore.getFromAddress`>>. Get the credential ID and public key associated with the given public address.
 
 This attribute is temporary until we implement a proper WebAuthn/oAuth solution and key delegation.
 
@@ -32,21 +33,21 @@ This attribute is temporary until we implement a proper WebAuthn/oAuth solution 
 
 == CDDL
 === `store`
-Store new credential ID and address in the persistent storage and return the associated recall phrase.
+Store new credential ID, public key, and address in the persistent storage and return the associated recall phrase.
 [sources,cddl]
 ----
 include::{cddl}/1002_idstore.cddl[tag=store]
 ----
 
 === `getFromRecallPhrase`
-Get the credential ID associated to the given recall phrase.
+Get the credential ID and public key associated with the given recall phrase.
 [sources,cddl]
 ----
 include::{cddl}/1002_idstore.cddl[tag=getFromRecallPhrase]
 ----
 
 === `getFromAddress`
-Get the credential ID associated to the given public address.
+Get the credential ID and public key associated with the given public address.
 [sources,cddl]
 ----
 include::{cddl}/1002_idstore.cddl[tag=getFromAddress]

--- a/attributes/network/cddl/1002_idstore.cddl
+++ b/attributes/network/cddl/1002_idstore.cddl
@@ -9,45 +9,45 @@ idstore-pubkey = bstr .cbor COSE_Key
 ; tag::store[]
 idstore.store@param = {
     ; The address associated with the credential ID and public key
-    0 => idstore-address
+    0 => idstore-address,
 
     ; The credential ID associated with the recall phrase
-    1 => idstore-credid
+    1 => idstore-credid,
 
     ; The public key associated with the recall phrase
-    2 => idstore-pubkey
+    2 => idstore-pubkey,
 }
 idstore.store@return = {
     ; The recall phrase associated with the credential ID and public key
-    0 => idstore-recall-phrase 
+    0 => idstore-recall-phrase, 
 }
 ; end::store[]
 
 ; tag::getFromRecallPhrase[]
 idstore.getFromRecallPhrase@param = {
     ; The recall phrase associated with the credential ID and public key
-    0 => idstore-recall-phrase 
+    0 => idstore-recall-phrase, 
 }
 idstore.idstore.getFromRecallPhrase@return = {
     ; The credential ID associated with the recall phrase
-    0 => idstore-credid
+    0 => idstore-credid,
 
     ; The public key associated with the recall phrase
-    1 => idstore-pubkey
+    1 => idstore-pubkey,
 }
 ; end::getFromRecallPhrase[]
 
 ; tag::getFromAddress[]
 idstore.getFromAddress@param = {
     ; The public address associated with the credential ID and public key
-    0 => idstore-address 
+    0 => idstore-address, 
 }
 idstore.getFromAddress@return = {
     ; The credential ID associated with the address
-    0 => idstore-credid
+    0 => idstore-credid,
 
     ; The public key associated with the address
-    1 => idstore-pubkey
+    1 => idstore-pubkey,
 }
 ; end::getFromAddress[]
 

--- a/attributes/network/cddl/1002_idstore.cddl
+++ b/attributes/network/cddl/1002_idstore.cddl
@@ -17,11 +17,17 @@ idstore.store@param = {
     ; The public key associated with the recall phrase
     2 => idstore-pubkey
 }
-idstore.store@return = idstore-recall-phrase ; The recall phrase associated with the credential ID and public key
+idstore.store@return = {
+    ; The recall phrase associated with the credential ID and public key
+    0 => idstore-recall-phrase 
+}
 ; end::store[]
 
 ; tag::getFromRecallPhrase[]
-idstore.getFromRecallPhrase@param = idstore-recall-phrase ; The recall phrase associated with the credential ID and public key
+idstore.getFromRecallPhrase@param = {
+    ; The recall phrase associated with the credential ID and public key
+    0 => idstore-recall-phrase 
+}
 idstore.idstore.getFromRecallPhrase@return = {
     ; The credential ID associated with the recall phrase
     0 => idstore-credid
@@ -32,7 +38,10 @@ idstore.idstore.getFromRecallPhrase@return = {
 ; end::getFromRecallPhrase[]
 
 ; tag::getFromAddress[]
-idstore.getFromAddress@param = idstore-address ; The public address associated with the credential ID and public key
+idstore.getFromAddress@param = {
+    ; The public address associated with the credential ID and public key
+    0 => idstore-address 
+}
 idstore.getFromAddress@return = {
     ; The credential ID associated with the address
     0 => idstore-credid

--- a/attributes/network/cddl/1002_idstore.cddl
+++ b/attributes/network/cddl/1002_idstore.cddl
@@ -3,42 +3,42 @@ word = tstr
 idstore-recall-phrase = [2*5 word]
 idstore-address = non-anonymous-identity
 idstore-credid = bstr .size (16..1023)
+idstore-pubkey = bstr .cbor COSE_Key
 ; end::types[]
 
 ; tag::store[]
 idstore.store@param = {
-    ; The address associated to the recall phrase
+    ; The address associated with the credential ID and public key
     0 => idstore-address
 
-    ; The credential ID associated to the recall phrase
+    ; The credential ID associated with the recall phrase
     1 => idstore-credid
+
+    ; The public key associated with the recall phrase
+    2 => idstore-pubkey
 }
-idstore.store@return = {
-    ; Recall phrase associated to the address and credential ID
-    0 => idstore-recall-phrase,
-}
+idstore.store@return = idstore-recall-phrase ; The recall phrase associated with the credential ID and public key
 ; end::store[]
 
 ; tag::getFromRecallPhrase[]
-idstore.getFromRecallPhrase@param = {
-    ; The recall phrase to be associated to the credential ID
-    0 => idstore-recall-phrase,
-}
+idstore.getFromRecallPhrase@param = idstore-recall-phrase ; The recall phrase associated with the credential ID and public key
 idstore.idstore.getFromRecallPhrase@return = {
-    ; The credential ID
+    ; The credential ID associated with the recall phrase
     0 => idstore-credid
+
+    ; The public key associated with the recall phrase
+    1 => idstore-pubkey
 }
 ; end::getFromRecallPhrase[]
 
 ; tag::getFromAddress[]
-idstore.getFromAddress@param = {
-    ; The public address associated to the credential ID
-    0 => idstore-address
-}
-
+idstore.getFromAddress@param = idstore-address ; The public address associated with the credential ID and public key
 idstore.getFromAddress@return = {
-    ; The credential ID
+    ; The credential ID associated with the address
     0 => idstore-credid
+
+    ; The public key associated with the address
+    1 => idstore-pubkey
 }
 ; end::getFromAddress[]
 


### PR DESCRIPTION
WebAuthn requires us to store the public key as well as the credentials.

See https://webauthn.guide/#registration

> If the validation process succeeded, the server would then store the publicKeyBytes and credentialId in a database, associated with the user. 