### PR TITLE
Create a new `memo` CDDL type

### DIFF
--- a/.github/workflows/cddl.yml
+++ b/.github/workflows/cddl.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build CDDL
-        run: find * -iname \*.cddl | xargs cat > temp.cddl
+        run: find * -iname \*.cddl | xargs cat > $HOME/temp.cddl
       - uses: docker://ghcr.io/anweiss/cddl-cli:latest
         with:
-          args: compile-cddl --cddl /github/workspace/temp.cddl
+          args: compile-cddl --cddl $HOME/temp.cddl

--- a/attributes/network/9_account_features/cddl/1_account_multisig.cddl
+++ b/attributes/network/9_account_features/cddl/1_account_multisig.cddl
@@ -5,8 +5,6 @@ account-role /= "canMultisigSubmit"
 
 account-multisig-token = bstr
 
-memo = tstr
-
 multisig-transaction-state /= 0  ; Pending
                             / 1  ; Executed automatically
                             / 2  ; Executed manually
@@ -50,8 +48,6 @@ account-multisig-event-info-submit = {
     6 => uint,                          ; The number of approvals needed.
     7 => time,                          ; Expiration date time.
     8 => bool,                          ; Whether to automatically execute.
-    ? 9 => bstr .cbor any,              ; CBOR data associated with the
-                                        ; transaction.
 }
 account-multisig-event-info-approve = {
     0 => account-event-type-multisig-approve,
@@ -173,8 +169,7 @@ account.multisigSubmitTransaction@param = {
     ; The account to submit the transaction to.
     0 => non-anonymous-identity,
 
-    ; A memo associated with the transaction. This is meant to be human readable
-    ; and can be used to explain the transaction to approvers.
+    ; A memo associated with the transaction.
     ? 1 => memo,
 
     ; The transaction to send. Must be a valid transaction understood by the
@@ -198,9 +193,6 @@ account.multisigSubmitTransaction@param = {
     ; The server MUST return an error if this value is passed but the submitter
     ; does not have the `owner` role, or if automatic execution is not supported.
     ? 5 => bool,
-
-    ; A CBOR associated data field.
-    ? 6 => bstr .cbor any,
 }
 account.multisigSubmitTransaction@return = {
     ; A token identifying this transaction. This is an implementation specific opaque
@@ -217,8 +209,7 @@ account.multisigInfo@param = {
 }
 
 account.multisigInfo@return = {
-    ; Memo sent when creating the transaction. This is meant to be human readable
-    ; and can be used to explain the transaction to approvers.
+    ; Memo sent when creating the transaction.
     ? 0 => memo,
 
     ; The transaction info.

--- a/attributes/network/9_account_features/cddl/1_account_multisig.cddl
+++ b/attributes/network/9_account_features/cddl/1_account_multisig.cddl
@@ -236,9 +236,6 @@ account.multisigInfo@return = {
     ; Unix EPOCH.
     6 => time,
 
-    ; A CBOR associated data field.
-    ? 7 => bstr .cbor any,
-
     ; A state of the transaction.
     8 => multisig-transaction-state,
 }

--- a/spec/cddl/types.cddl
+++ b/spec/cddl/types.cddl
@@ -38,14 +38,8 @@ sub-attribute-related-index = [attribute-id, uint]
 
 ; A memo contains a human readable portion and/or a machine readable portion.
 ; The machine readable portion is expected to be CBOR, though it could be a
-; byte array. Both are optional.
-; A memo CANNOT be empty (both fields missing).
-memo = { human-readable-memo }
-     / { machine-readable-memo }
-     / { human-readable-memo, machine-readable-memo }
-
-; The human readable part of the memo.
-human-readable-memo = ( 0 => tstr )
-
-; The machine readable part of the memo.
-machine-readable-memo = ( 1 => bstr .cbor any )
+; byte array containing another format.
+; A memo can contain multiple entries, as some of them might be formatted in
+; different ways, or contain additional data.
+; The memo itself CANNOT be empty and MUST contain at least one entry.
+memo = [ + (tstr / (bstr .cbor any)) ]

--- a/spec/cddl/types.cddl
+++ b/spec/cddl/types.cddl
@@ -35,3 +35,17 @@ range<T> = {
 attribute-related-index     = attribute-id / sub-attribute-related-index
 sub-attribute-related-index = [attribute-id, uint]
                             / [attribute-id, sub-attribute-related-index]
+
+; A memo contains a human readable portion and/or a machine readable portion.
+; The machine readable portion is expected to be CBOR, though it could be a
+; byte array. Both are optional.
+; A memo CANNOT be empty (both fields missing).
+memo = { human-readable-memo }
+     / { machine-readable-memo }
+     / { human-readable-memo, machine-readable-memo }
+
+; The human readable part of the memo.
+human-readable-memo = ( 0 => tstr )
+
+; The machine readable part of the memo.
+machine-readable-memo = ( 1 => bstr .cbor any )


### PR DESCRIPTION
This streamlines human and machine-readable memos. Prior to this it was specific to multisig transactions but we will add more of these memos throughout the specification and having a global unique type will help.

# Breaking
This is a breaking change, so there might be some inconsistencies in the alpha network. It is acceptable as we can change types in non-backward compatible ways while in alpha.

# Follow-up
Additional work for Memo can be done in a backward compatible way; it will be mostly adding types to the human readable portion for formatting (e.g. Markdown vs Plain text).

----
Ref #57 