### PR TITLE
Fix CI by adding an order to the evaluation of rules

### DIFF
--- a/.github/workflows/cddl.yml
+++ b/.github/workflows/cddl.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build CDDL
-        run: find * -iname \*.cddl | xargs cat > temp.cddl
+        run: bash scripts/make_cddl.bash temp.cddl
       - uses: docker://ghcr.io/anweiss/cddl-cli:latest
         with:
           args: compile-cddl --cddl temp.cddl

--- a/.github/workflows/cddl.yml
+++ b/.github/workflows/cddl.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build CDDL
-        run: bash scripts/make_cddl.bash temp.cddl
+        run: bash scripts/make_cddl.bash ./temp.cddl
       - uses: docker://ghcr.io/anweiss/cddl-cli:latest
         with:
           args: compile-cddl --cddl temp.cddl

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CDDL_FILES := $(shell find * -type f -name \*.cddl -a \( \! -path target/\* \))
+CDDL_FILES := $(shell find * -type f -name \*.cddl -a \( \! -path target/all.cddl \))
 .PHONY: cddl-check clean
 
 clean:
@@ -7,11 +7,11 @@ clean:
 target/all.cddl: $(CDDL_FILES)
 	mkdir -p "$(@D)"
 	rm target/all.cddl || true
-	cat $(CDDL_FILES) >> target/all.cddl
+	scripts/make_cddl.bash target/all.cddl
 
 target/bin/cddl:
 	cargo install cddl --root target/
 
 cddl-check: target/all.cddl target/bin/cddl
 	target/bin/cddl compile-cddl --cddl target/all.cddl
- 
+

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -11,6 +11,8 @@ find_cddl() {
     done
 }
 
+find_cddl "$(dirname "$(dirname "$0")")"
+echo '-----------'
 find_cddl "$(dirname "$(dirname "$0")")" | xargs cat > "$1"
 
 echo "$1":

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -11,8 +11,8 @@ find_cddl() {
 }
 
 {
-    find_cddl "$(dirname "$(dirname "$0")")"/spec | xargs cat
-    find_cddl "$(dirname "$(dirname "$0")")"/attributes | xargs cat
+    find_cddl "$(dirname "$(dirname "$0")")"/spec | xargs --null cat
+    find_cddl "$(dirname "$(dirname "$0")")"/attributes | xargs --null cat
 } > "$1"
 
 echo "$1":

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -3,6 +3,8 @@
 find_cddl() {
     local i
 
+    man find
+
     # List all in directory order (breadth-first), and remove the files
     # that aren't part of the repository from the list.
     for i in 0 1 2 3 4 5 6 7 8; do

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -8,14 +8,14 @@ find_cddl() {
     # List all in directory order (breadth-first), and remove the files
     # that aren't part of the repository from the list.
     for i in 0 1 2 3 4 5 6 7 8; do
-        find "$1" -mindepth "$i" -maxdepth "$i" -iname \*.cddl -print0 \
-            | xargs -0 git ls-files --exclude-standard
+        find "$1" -mindepth "$i" -maxdepth "$i" -iname \*.cddl -print0
     done
 }
 
-find_cddl "$(dirname "$(dirname "$0")")"
-echo '-----------'
-find_cddl "$(dirname "$(dirname "$0")")" | xargs cat > "$1"
+{
+    find_cddl "$(dirname "$(dirname "$0")")"/spec | xargs cat
+    find_cddl "$(dirname "$(dirname "$0")")"/attributes | xargs cat
+} > "$1"
 
 echo "$1":
 cat "$1"

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -12,3 +12,6 @@ find_cddl() {
 }
 
 find_cddl "$(dirname "$(dirname "$0")")" | xargs cat > "$1"
+
+echo "$1":
+cat "$1"

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -3,8 +3,6 @@
 find_cddl() {
     local i
 
-    man find
-
     # List all in directory order (breadth-first), and remove the files
     # that aren't part of the repository from the list.
     for i in 0 1 2 3 4 5 6 7 8; do

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+find_cddl() {
+    local i
+
+    # List all in directory order (breadth-first), and remove the files
+    # that aren't part of the repository from the list.
+    for i in 0 1 2 3 4 5 6 7 8; do
+        find "$1" -mindepth $i -maxdepth $i -iname \*.cddl \
+            | xargs git ls-files --exclude-standard
+    done
+}
+
+find_cddl "$(dirname "$(dirname "$0")")" | xargs cat > "$1"

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -14,6 +14,3 @@ find_cddl() {
     find_cddl "$(dirname "$(dirname "$0")")"/spec | xargs --null cat
     find_cddl "$(dirname "$(dirname "$0")")"/attributes | xargs --null cat
 } > "$1"
-
-echo "$1":
-cat "$1"

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -6,8 +6,8 @@ find_cddl() {
     # List all in directory order (breadth-first), and remove the files
     # that aren't part of the repository from the list.
     for i in 0 1 2 3 4 5 6 7 8; do
-        find "$1" -mindepth $i -maxdepth $i -iname \*.cddl \
-            | xargs git ls-files --exclude-standard
+        find "$1" -mindepth "$i" -maxdepth "$i" -iname \*.cddl -print0 \
+            | xargs -0 git ls-files --exclude-standard
     done
 }
 


### PR DESCRIPTION
Before it was alphabetical, now we do breadth-first to allow for types defined in directories above to be used. We also now use the gitignore rules instead of just singling out target.