### PR TITLE
Burn the fields we use for the legacy memo

### DIFF
--- a/attributes/network/9_account_features/cddl/1_account_multisig.cddl
+++ b/attributes/network/9_account_features/cddl/1_account_multisig.cddl
@@ -56,7 +56,7 @@ account-multisig-event-info-submit = {
     7 => time,                          ; Expiration date time.
     8 => bool,                          ; Whether to automatically execute.
     ? 9 => burnt<bstr>,                 ; DO NOT USE. Previous memo.
-    10 => memo,                         ; Memo of the transaction
+    ? 10 => memo,                       ; Memo of the transaction
 }
 account-multisig-event-info-approve = {
     0 => account-event-type-multisig-approve,

--- a/attributes/network/9_account_features/cddl/1_account_multisig.cddl
+++ b/attributes/network/9_account_features/cddl/1_account_multisig.cddl
@@ -49,12 +49,14 @@ account-multisig-event-info-submit = {
     0 => account-event-type-multisig-submit,
     1 => non-anonymous-address,         ; Submitter
     2 => non-anonymous-address,         ; Account source
-    ? 3 => memo,                        ; Memo of the transaction
+    ? 3 => burnt<tstr>,                 ; DO NOT USE. Previous memo.
     4 => account-multisig-transaction,  ; The transaction submitted
     5 => account-multisig-token,        ; Token created by the submission.
     6 => uint,                          ; The number of approvals needed.
     7 => time,                          ; Expiration date time.
     8 => bool,                          ; Whether to automatically execute.
+    ? 9 => burnt<bstr>,                 ; DO NOT USE. Previous memo.
+    10 => memo,                         ; Memo of the transaction
 }
 account-multisig-event-info-approve = {
     0 => account-event-type-multisig-approve,
@@ -176,8 +178,8 @@ account.multisigSubmitTransaction@param = {
     ; The account to submit the transaction to.
     0 => non-anonymous-address,
 
-    ; A memo associated with the transaction.
-    ? 1 => memo,
+    ; DO NOT USE. Previous memo.
+    ? 1 => burnt<tstr>,
 
     ; The transaction to send. Must be a valid transaction understood by the
     ; server.
@@ -200,6 +202,12 @@ account.multisigSubmitTransaction@param = {
     ; The server MUST return an error if this value is passed but the submitter
     ; does not have the `owner` role, or if automatic execution is not supported.
     ? 5 => bool,
+
+    ; A CBOR associated data field.
+    ? 6 => burnt<bstr>,
+
+    ; A memo associated with the transaction.
+    ? 7 => memo,
 }
 account.multisigSubmitTransaction@return = {
     ; A token identifying this transaction. This is an implementation specific opaque
@@ -216,8 +224,8 @@ account.multisigInfo@param = {
 }
 
 account.multisigInfo@return = {
-    ; Memo sent when creating the transaction.
-    ? 0 => memo,
+    ; DO NOT USE. Previous memo.
+    ? 0 => burnt<tstr>,
 
     ; The transaction info.
     1 => account-multisig-transaction,
@@ -243,8 +251,14 @@ account.multisigInfo@return = {
     ; Unix EPOCH.
     6 => time,
 
+    ; DO NOT USE. Previous data.
+    ? 7 => burnt<bstr>,
+
     ; A state of the transaction.
     8 => multisig-transaction-state,
+
+    ; Memo sent when creating the transaction.
+    ? 9 => memo,
 }
 ; end::info[]
 

--- a/scripts/make_cddl.bash
+++ b/scripts/make_cddl.bash
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
 find_cddl() {
-    local i
+    local i filename
 
     # List all in directory order (breadth-first), and remove the files
     # that aren't part of the repository from the list.
+    # Sort by basename.
     for i in 0 1 2 3 4 5 6 7 8; do
-        find "$1" -mindepth "$i" -maxdepth "$i" -iname \*.cddl -print0
+        find "$1" -mindepth "$i" -maxdepth "$i" -iname \*.cddl | while read -r filename
+        do
+            echo "$(basename "$filename"):$filename"
+        done | sort -n | awk -F: '{ print $2 }'
     done
 }
 
 {
-    find_cddl "$(dirname "$(dirname "$0")")"/spec | xargs --null cat
-    find_cddl "$(dirname "$(dirname "$0")")"/attributes | xargs --null cat
-} > "$1"
+    find_cddl "$(dirname "$(dirname "$0")")"/spec
+    find_cddl "$(dirname "$(dirname "$0")")"/attributes/network
+    find_cddl "$(dirname "$(dirname "$0")")"/attributes/request
+    find_cddl "$(dirname "$(dirname "$0")")"/attributes/response
+} | xargs cat > "$1"

--- a/spec/cddl/types.cddl
+++ b/spec/cddl/types.cddl
@@ -45,3 +45,8 @@ sub-attribute-related-index = [attribute-id, uint]
 ; different ways, or contain additional data.
 ; The memo itself CANNOT be empty and MUST contain at least one entry.
 memo = [ + (tstr / (bstr .cbor any)) ]
+
+; A burnt field is any valid CBOR value, but is used to indicate that this
+; field should not be used anymore. It is normally kept as a backward compatible
+; placeholder. Always should be used with an optional key in a map.
+burnt<T = any> = T

--- a/spec/cddl/types.cddl
+++ b/spec/cddl/types.cddl
@@ -49,4 +49,4 @@ memo = [ + (tstr / (bstr .cbor any)) ]
 ; A burnt field is any valid CBOR value, but is used to indicate that this
 ; field should not be used anymore. It is normally kept as a backward compatible
 ; placeholder. Always should be used with an optional key in a map.
-burnt<T = any> = T
+burnt<T> = T

--- a/spec/deprecation.adoc
+++ b/spec/deprecation.adoc
@@ -1,0 +1,67 @@
+= Deprecation Policy
+:cddl: ./cddl/
+// Metadata
+:toc:
+:hide-uri-scheme:
+
+As we are still in Alpha phase of the protocol, we allow some fields to be deprecated and "burnt".
+This is to allow some velocity in the design and experimentation while we finalize the protocol.
+
+== Burning Fields
+
+During Alpha, it is still possible to remove and replace fields.
+This is done by burning the old fields and add new fields.
+
+To burn a field, replace its type with `burnt<ORIGINAL_TYPE>` (see the xref:{cddl}/types.cddl[burnt type]), and ensure that it is optional.
+Indicate clearly in a comment not to use the field for anything else.
+The new fields should also be marked as optional.
+
+This allows us to keep backward compatibility.
+Fields that are burnt this way should be moved out of the implementations gradually.
+
+For example, when reworking the `memo` field from a `tstr` to an array containing either text or byte strings (`[ + (tstr / (bstr .cbor any)) ]`), all memo fields were replaced with `burnt<tstr>`, and the new type used new indices in the maps to replace the old fields.
+This lead to the following change:
+
+.`multisig.cddl` original
+[source,cddl]
+----
+account-multisig-event-info-submit = {
+    0 => account-event-type-multisig-submit,
+    1 => non-anonymous-identity,        ; Submitter
+    2 => non-anonymous-identity,        ; Account source
+    ? 3 => memo,                        ; Memo of the transaction
+    4 => account-multisig-transaction,  ; The transaction submitted
+    5 => account-multisig-token,        ; Token created by the submission.
+    6 => uint,                          ; The number of approvals needed.
+    7 => time,                          ; Expiration date time.
+    8 => bool,                          ; Whether to automatically execute.
+    ? 9 => bstr .cbor any,              ; CBOR data associated with the
+                                        ; transaction.
+}
+----
+
+.`multisig.cddl` with burnt fields
+[source,cddl]
+----
+account-multisig-event-info-submit = {
+    0 => account-event-type-multisig-submit,
+    1 => non-anonymous-address,         ; Submitter
+    2 => non-anonymous-address,         ; Account source
+    ? 3 => burnt<tstr>,                 ; DO NOT USE. Previous memo.
+    4 => account-multisig-transaction,  ; The transaction submitted
+    5 => account-multisig-token,        ; Token created by the submission.
+    6 => uint,                          ; The number of approvals needed.
+    7 => time,                          ; Expiration date time.
+    8 => bool,                          ; Whether to automatically execute.
+    ? 9 => burnt<bstr>,                 ; DO NOT USE. Previous memo.
+    ? 10 => memo,                       ; Memo of the transaction
+}
+----
+
+== Beta
+
+Once the protocol itself is in Beta, we will not allow removing existing fields anymore, to ensure backward compatibility.
+This means that existing files will become immutable (outside of documentation PRs).
+Security issues should be resolved by deprecating but not removing attributes, and create new attributes with the correct properties.
+
+We do not have criteria or a timeline for moving the specification to Beta.


### PR DESCRIPTION
This is to only have to add new types, and remove the need for legacy types. Those fields can be used but shouldnt and are optionals.