### PR TITLE
Request and response for a transaction can always be empty, and not just when they are too large to fit

### DIFF
--- a/attributes/network/cddl/1_blockchain.cddl
+++ b/attributes/network/cddl/1_blockchain.cddl
@@ -60,15 +60,13 @@ transaction = {
     0 => transaction-identifier,
 
     ; The content of the transaction. This should be a MANY request.
-    ; If this field is missing, the transaction was too large to fit here and
-    ; should be queried separately. Use the `block.request` endpoint.
+    ; If this field is missing, use the `block.request` endpoint.
     ; If this field is there but empty (not a request), the transaction is
     ; empty or metadata-only (implementation specific).
     ? 1 => bstr .cbor request / bstr .size 0,
 
     ; The response for the transaction. This should be a MANY response.
-    ; If this field is missing, the response might be too large to fit in a single
-    ; response.  Use the `block.response` endpoint.
+    ; If this field is missing, use the `block.response` endpoint.
     ; If this field is empty, the transaction is empty or metadata-only
     ; (implementation specific).
     ? 2 => bstr .cbor response / bstr .size 0,


### PR DESCRIPTION
This PR resolves https://github.com/many-protocol/specification/issues/87