### PR TITLE
feat: dweb

### DIFF
--- a/attributes/network/16_web.adoc
+++ b/attributes/network/16_web.adoc
@@ -1,0 +1,6 @@
+:cddl: ./cddl/
+
+[sources,cddl]
+----
+include::{cddl}/16_web.cddl[]
+----

--- a/attributes/network/17_web_commands.adoc
+++ b/attributes/network/17_web_commands.adoc
@@ -1,0 +1,6 @@
+:cddl: ./cddl/
+
+[sources,cddl]
+----
+include::{cddl}/17_web_commands.cddl[]
+----

--- a/attributes/network/cddl/16_web.cddl
+++ b/attributes/network/cddl/16_web.cddl
@@ -1,0 +1,55 @@
+; tag::types[]
+repo-meta = {
+    ; Repository URL
+    0 => tstr,
+
+    ; Build artifact path inside the repository
+    ? 1 => tstr,
+}
+
+github-src = [0, repo-meta]
+web-deployment-src = github-src
+web-deployment-info = {
+    ; Site name
+    0 => tstr,
+
+    ; Site description
+    ? 1 => tstr,
+
+    ; Deployment source
+    2 => web-deployment-src,
+
+    ; Deployment URL
+    3 => tstr,
+}
+
+web-deployment-filter = [0, {}] ; All
+                      / [1, {0: non-anonymous-address}] ; Owner
+; end::types[]
+
+; tag::info[]
+; `web.info` endpoint.
+web.info@param = ()
+web.info@return = {
+    ; Hash of the current storage state.
+    0 => bstr,
+}
+; end::info[]
+
+; tag::list[]
+; `web.list` endpoint.
+web.list@param = {
+    ; Owner
+    ? 0 => non-anonymous-address,
+
+    ; Order
+    ? 1 => order,
+
+    ; Filter
+    ? 2 => web-deployment-filter,
+}
+web.list@return = {
+    ; List of sites
+    0 = [* web-deployment-info],
+}
+; end::list[]

--- a/attributes/network/cddl/16_web.cddl
+++ b/attributes/network/cddl/16_web.cddl
@@ -1,14 +1,6 @@
 ; tag::types[]
-repo-meta = {
-    ; Repository URL
-    0 => tstr,
-
-    ; Build artifact path inside the repository
-    ? 1 => tstr,
-}
-
-github-src = [0, repo-meta]
-web-deployment-src = github-src
+zip-src = [0, {0: bstr}] ; Zip archive
+web-deployment-src = zip-src
 web-deployment-info = {
     ; Site name
     0 => tstr,
@@ -16,11 +8,8 @@ web-deployment-info = {
     ; Site description
     ? 1 => tstr,
 
-    ; Deployment source
-    2 => web-deployment-src,
-
     ; Deployment URL
-    3 => tstr,
+    2 => tstr,
 }
 
 web-deployment-filter = [0, {}] ; All

--- a/attributes/network/cddl/17_web_commands.cddl
+++ b/attributes/network/cddl/17_web_commands.cddl
@@ -1,0 +1,27 @@
+; tag::deploy[]
+; `web.deploy` endpoint.
+web.deploy@param = {
+    ; Site name
+    0 => tstr,
+
+    ; Site description
+    ? 1 => tstr,
+
+    ; Deployment source
+    2 => web-deployment-src,
+}
+
+web.deploy@return = {
+    ; Deployment URL
+    0 => tstr,
+}
+; end::deploy[]
+
+; tag::remove[]
+; `web.remove` endpoint.
+web.remove@param = {
+    ; Site name
+    0 => tstr,
+}
+web.remove@return = ()
+; end::remove[]


### PR DESCRIPTION
Spec work for decentralized web hosting. This is still a WIP.

Currently limited to transferring the whole website archive in one (big) transaction.
Archive size is limited to 5MB.

Food for thought
- We could perhaps get rid of this limitation by uploading files one by one, or batch them?
  - This will not be convenient for HSM users.